### PR TITLE
Get classification store attributes

### DIFF
--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -18,7 +18,6 @@ namespace OutputDataConfigToolkitBundle\ConfigElement\Value;
 use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\DefaultMockup;
 use Pimcore\Model\DataObject\AbstractObject;
-use Pimcore\Model\DataObject\Localizedfield;
 use Pimcore\Model\DataObject\Classificationstore;
 
 class DefaultValue extends AbstractConfigElement
@@ -65,12 +64,12 @@ class DefaultValue extends AbstractConfigElement
                 $brickTypeGetter = 'get' . ucfirst($brickType);
                 $brickGetter = 'get' . ucfirst($brickKey);
             }
-        } elseif (substr($this->attribute, 0, 4) == "#cs#") {
+        } elseif (substr($this->attribute, 0, 4) == '#cs#') {
             // checking classification store fieldname
             if (!$this->classificationstore) {
                 return null;
             }
-            $getter = "get" . ucfirst($this->classificationstore);
+            $getter = 'get' . ucfirst($this->classificationstore);
             // checking classification sote group
             if (!$this->classificationstore_group) {
                 return null;
@@ -78,8 +77,8 @@ class DefaultValue extends AbstractConfigElement
             $groupDef = Classificationstore\GroupConfig::getByName($this->classificationstore_group);
 
             // classification store
-            $attribute = str_replace("#cs#", "", $this->attribute);
-            list($keyId) = explode("#", $attribute);
+            $attribute = str_replace('#cs#', '', $this->attribute);
+            list($keyId) = explode('#', $attribute);
 
             $value = $object->$getter()->getLocalizedKeyValue($groupDef->getId(), $keyId);
 
@@ -93,11 +92,12 @@ class DefaultValue extends AbstractConfigElement
                 $result->def = \Pimcore\Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($config);
             }
 
-            if (empty($value) || (is_object($value) && method_exists($value, "isEmpty") && $value->isEmpty())) {
+            if (empty($value) || (is_object($value) && method_exists($value, 'isEmpty') && $value->isEmpty())) {
                 $result->empty = true;
             } else {
                 $result->empty = false;
             }
+
             return $result;
         }
         if (method_exists($object, $getter) || $object instanceof DefaultMockup) {

--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -19,6 +19,7 @@ use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\DefaultMockup;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Localizedfield;
+use Pimcore\Model\DataObject\Classificationstore;
 
 class DefaultValue extends AbstractConfigElement {
 

--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -65,6 +65,40 @@ class DefaultValue extends AbstractConfigElement {
                 $brickTypeGetter = "get" . ucfirst($brickType);
                 $brickGetter = "get" . ucfirst($brickKey);
             }
+        } elseif (substr($this->attribute, 0, 4) == "#cs#") {
+            // checking classification store fieldname
+            if (!$this->classificationstore) {
+                return null;
+            }
+            $getter = "get" . ucfirst($this->classificationstore);
+            // checking classification sote group
+            if (!$this->classificationstore_group) {
+                return null;
+            }
+            $groupDef = Classificationstore\GroupConfig::getByName($this->classificationstore_group);
+
+            // classification store
+            $attribute = str_replace("#cs#", "", $this->attribute);
+            list($keyId) = explode("#", $attribute);
+
+            $value = $object->$getter()->getLocalizedKeyValue($groupDef->getId(), $keyId);
+
+            $result = new \stdClass();
+            $result->value = $value;
+            $result->label = $this->label;
+            $result->attribute = $this->attribute;
+
+            $config = Classificationstore\KeyConfig::getById($keyId);
+            if ($config) {
+                $result->def = \Pimcore\Model\DataObject\Classificationstore\Service::getFieldDefinitionFromKeyConfig($config);
+            }
+
+            if (empty($value) || (is_object($value) && method_exists($value, "isEmpty") && $value->isEmpty())) {
+                $result->empty = true;
+            } else {
+                $result->empty = false;
+            }
+            return $result;
         }
         if(method_exists($object, $getter) || $object instanceof DefaultMockup) {
             $value = $object->$getter();


### PR DESCRIPTION
Added code on DefaultValue in the output channel bundle that could use some sort of classification store getter to extract a value if it is prefixed with #cs#