### PR TITLE
Fixes some errors when using the bundle with Pimcore 10 and PHP 8

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -242,13 +242,17 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
                 if (!empty($newConfig->label)) {
                     $newConfig->text = $newConfig->label;
                 } else {
-                    $def = $this->getFieldDefinition($newConfig->attribute, $objectClass);
+                    $def = null;
+                    if (isset($newConfig->attribute)) {
+                        $def = $this->getFieldDefinition($newConfig->attribute, $objectClass);
+                    }
+                    
                     if ($def) {
                         $translator = $this->get('translator');
                         $newConfig->text = $translator->trans($def->getTitle(), [], 'admin');
                     }
 
-                    if ($newConfig->dataType == 'system') {
+                    if (isset($newConfig->dataType) && $newConfig->dataType == 'system' && isset($newConfig->attribute)) {
                         $newConfig->text = $newConfig->attribute;
                     }
                 }


### PR DESCRIPTION
When adding an operator to an output channel, there is an error in the action "AdminController::getOutputConfigAction" with the message "Warning: Undefined property: stdClass::$attribute".
This pull request solve the error.
This pull request is for branch 4.1.