### PR TITLE
Replace deprecated ts() function with t()

### DIFF
--- a/src/Resources/public/js/ClassTree.js
+++ b/src/Resources/public/js/ClassTree.js
@@ -35,7 +35,7 @@ pimcore.bundle.outputDataConfigToolkit.ClassTree = Class.create(pimcore.object.h
                             brickField: nodeData.brickField
                         };
 
-                        text = ts(nodeData.nodeLabel) + " " + t("columns");
+                        text = t(nodeData.nodeLabel) + " " + t("columns");
 
                     }
 
@@ -191,7 +191,7 @@ pimcore.bundle.outputDataConfigToolkit.ClassTree = Class.create(pimcore.object.h
                 key = "#cs#" + classificationDescriptor.keyConfig.id + "#" + classificationDescriptor.keyConfig.name
             }
 
-            var text = ts(initData.title);
+            var text = t(initData.title);
             if (showFieldname) {
                 if (brickDescriptor && brickDescriptor.insideBrick && brickDescriptor.insideLocalizedFields) {
                     text = text + "(" + brickDescriptor.brickType + "." + initData.name + ")";

--- a/src/Resources/public/js/OutputDataConfigDialog.js
+++ b/src/Resources/public/js/OutputDataConfigDialog.js
@@ -47,7 +47,7 @@ pimcore.bundle.outputDataConfigToolkit.OutputDataConfigDialog = Class.create(pim
             height: 650,
             modal: true,
             iconCls: "bundle_outputdataconfig_icon",
-            title: t('output_channel_definition_for') + " " + ts(this.outputConfig.channel),
+            title: t('output_channel_definition_for') + " " + t(this.outputConfig.channel),
             layout: "fit",
             items: [this.configPanel]
         });


### PR DESCRIPTION
ts() is deprecated since Pimcore 6.5.2 https://github.com/pimcore/pimcore/pull/5840
Throws console errors since Pimcore 10.5.0 https://github.com/pimcore/pimcore/pull/12771
Will be removed in Pimcore 11.0.0 https://github.com/pimcore/pimcore/pull/12826