### PR TITLE
Fixed the Array to string Warning

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -450,8 +450,8 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
             $allowedClassIds = [];
             foreach ($this->defaultGridClasses as $allowedClass) {
                 $classNamespace = 'Pimcore\\Model\\DataObject\\';
-                $allowedClass = explode('\\', $allowedClass);
-                $allowedClassFull = $classNamespace . array_pop($allowedClass);
+                $allowedClassArr = explode('\\', $allowedClass);
+                $allowedClassFull = $classNamespace . array_pop($allowedClassArr);
                 if (class_exists($allowedClassFull)) {
                     $allowedClassIds[] = call_user_func([$allowedClassFull, 'classId']);
                 } else {


### PR DESCRIPTION
When the output data configuration is loaded without selecting a class, a warning message is shown.