### PR TITLE
Prevent error when upgrading from older versions

### DIFF
--- a/src/ConfigElement/Operator/Concatenator.php
+++ b/src/ConfigElement/Operator/Concatenator.php
@@ -25,8 +25,8 @@ class Concatenator extends AbstractOperator
     {
         parent::__construct($config, $context);
         $this->glue = $config->glue;
-        $this->forceValue = $config->forceValue;
-        $this->formatNumbers = $config->formatNumbers;
+        $this->forceValue = $config->forceValue ?? false;
+        $this->formatNumbers = $config->formatNumbers ?? false;
     }
 
     public function getLabeledValue($object)


### PR DESCRIPTION
Set default values to prevent error when uprading from older versions which don't have "formatNumbers" defined.

An exception has been thrown during the rendering of a template ("Warning: Undefined property: stdClass::$formatNumbers File: /home/xxx/www/vendor/pimcore/output-data-config-toolkit-bundle/src/ConfigElement/Operator/Concatenator.php Line: 29").