### PR TITLE
Concatenator bugfixes

### DIFF
--- a/src/ConfigElement/Operator/Concatenator.php
+++ b/src/ConfigElement/Operator/Concatenator.php
@@ -47,8 +47,10 @@ class Concatenator extends AbstractOperator
             $value = $c->getLabeledValue($object) ? $c->getLabeledValue($object)->value : null;
 
             if (!$hasValue) {
-                if (!empty($value) || (is_object($value) && (method_exists($value, 'isEmpty') && !$value->isEmpty()))) {
-                    $hasValue = true;
+                if (is_object($value) && method_exists($value, 'isEmpty')) {
+                    $hasValue = !$value->isEmpty();
+                } else {
+                    $hasValue = !empty($value);
                 }
             }
 

--- a/src/ConfigElement/Operator/Concatenator.php
+++ b/src/ConfigElement/Operator/Concatenator.php
@@ -32,6 +32,7 @@ class Concatenator extends AbstractOperator
     public function getLabeledValue($object)
     {
         $result = new \stdClass();
+        $result->value = null;
         $result->label = $this->label;
 
         $hasValue = true;
@@ -46,7 +47,7 @@ class Concatenator extends AbstractOperator
             $value = $c->getLabeledValue($object) ? $c->getLabeledValue($object)->value : null;
 
             if (!$hasValue) {
-                if (!empty($value) || ((method_exists($value, 'isEmpty') && !$value->isEmpty()))) {
+                if (!empty($value) || (is_object($value) && (method_exists($value, 'isEmpty') && !$value->isEmpty()))) {
                     $hasValue = true;
                 }
             }


### PR DESCRIPTION
1) Add "value" field with a default of "null" so we don't need to check in further code if the property exists on the result

2) Fix "method_exits" on null values
![image](https://user-images.githubusercontent.com/8791970/208051577-f2bed017-7d25-4221-883d-ad9746855d89.png)
