### PR TITLE
[Task]: Verfiy identifyer quoting for sql queries

### DIFF
--- a/src/OutputDefinition/Dao.php
+++ b/src/OutputDefinition/Dao.php
@@ -46,7 +46,7 @@ class Dao extends \Pimcore\Model\Dao\AbstractDao
      */
     public function getByO_IdClassIdChannel($o_id, $classId, $channel)
     {
-        $outputDefinitionRaw = $this->db->fetchRow('SELECT * FROM ' . self::TABLE_NAME . ' WHERE o_id=? AND o_classId = ? AND channel = ?', [$o_id, $classId, $channel]);
+        $outputDefinitionRaw = $this->db->fetchRow('SELECT * FROM ' . self::TABLE_NAME . ' WHERE o_id=? AND o_classId = ? AND ' . $this->db->quoteIdentifier('channel') . ' = ?', [$o_id, $classId, $channel]);
         if (empty($outputDefinitionRaw)) {
             throw new \Exception('OutputDefinition ' . $o_id . ' - ' . $classId  . ' - ' . $channel . ' not found.');
         }

--- a/src/OutputDefinition/Listing/Dao.php
+++ b/src/OutputDefinition/Listing/Dao.php
@@ -33,7 +33,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
         $params = array_column($this->model->getConditionParams() ?: [], 'value');
 
-        $unitIds = $this->db->fetchAll('SELECT o_id, id, o_classId, channel FROM ' . OutputDefinition\Dao::TABLE_NAME .
+        $unitIds = $this->db->fetchAll('SELECT o_id, id, o_classId, ' . $this->db->quoteIdentifier('channel') . ' FROM ' . OutputDefinition\Dao::TABLE_NAME .
             $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $params);
 
         foreach ($unitIds as $row) {


### PR DESCRIPTION
Related https://github.com/pimcore/output-data-config-toolkit/issues/64

For [MariaDB](https://mariadb.com/kb/en/reserved-words/#:~:text=CHAR-,CHARACTER,-CHECK), `CHANNEL` is not a reserved keyword, but it is for [MySQL](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#:~:text=CHANGED-,CHANNEL,-CHAR%20(R)), maybe should be considered as potential bug?
