### PR TITLE
[Task] Removed support for Pimcore `10.6`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,20 +5,13 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "pimcore/pimcore": "^10.6 || ^11.0",
-    "symfony/config": "^5.3 || ^6.1",
-    "symfony/dependency-injection": "^5.3 || ^6.1",
-    "symfony/event-dispatcher": "^5.3 || ^6.1",
-    "symfony/event-dispatcher-contracts": "^2.2 || ^3.0",
-    "symfony/http-foundation": "^5.3 || ^6.1",
-    "symfony/http-kernel": "^5.3 || ^6.1",
-    "symfony/routing": "^5.3 || ^6.1",
-    "symfony/templating": "^5.3 || ^6.1",
+    "pimcore/pimcore": "^11.0",
+    "symfony/event-dispatcher-contracts": "^3.0",
     "pimcore/ecommerce-framework-bundle": "1.x-dev"
   },
   "require-dev": {
-    "phpstan/phpstan": "^1.8.2",
-    "phpstan/phpstan-symfony": "^1.2.9"
+    "phpstan/phpstan": "^1.10.5",
+    "phpstan/phpstan-symfony": "^1.2.20"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,14 @@
   "minimum-stability": "dev",
   "require": {
     "pimcore/pimcore": "^11.0",
+    "symfony/config": "^6.2",
+    "symfony/dependency-injection": "^6.2",
+    "symfony/event-dispatcher": "^6.2",
     "symfony/event-dispatcher-contracts": "^3.0",
+    "symfony/http-foundation": "^6.2",
+    "symfony/http-kernel": "^6.2",
+    "symfony/routing": "^6.2",
+    "symfony/templating": "^6.2",
     "pimcore/ecommerce-framework-bundle": "1.x-dev"
   },
   "require-dev": {


### PR DESCRIPTION
Each Bundle that requires the https://github.com/pimcore/ecommerce-framework-bundle has to drop support for 10.6.

Followup to: #82