### PR TITLE
[Bug]: Refactor migration to change column instead of rename

### DIFF
--- a/src/Migrations/Version20221130082116.php
+++ b/src/Migrations/Version20221130082116.php
@@ -35,12 +35,12 @@ final class Version20221130082116 extends AbstractMigration
         $table = $schema->getTable('bundle_outputdataconfigtoolkit_outputdefinition');
 
         if ($table->hasColumn('o_classId')) {
-            $query = 'ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`';
+            $query = 'ALTER TABLE `%s` CHANGE COLUMN `%s` `%s` varchar(50) NOT NULL';
             $this->addSql(sprintf($query, $table->getName(), 'o_classId', 'classId'));
         }
 
         if ($table->hasColumn('o_id')) {
-            $query = 'ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`';
+            $query = 'ALTER TABLE `%s` CHANGE COLUMN `%s` `%s` int(11) NOT NULL';
             $this->addSql(sprintf($query, $table->getName(), 'o_id', 'objectId'));
         }
     }
@@ -50,12 +50,12 @@ final class Version20221130082116 extends AbstractMigration
         $table = $schema->getTable('bundle_outputdataconfigtoolkit_outputdefinition');
 
         if ($table->hasColumn('classId')) {
-            $query = 'ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`';
+            $query = 'ALTER TABLE `%s` CHANGE COLUMN `%s` `%s` varchar(50) NOT NULL';
             $this->addSql(sprintf($query, $table->getName(), 'classId', 'o_classId'));
         }
 
         if ($table->hasColumn('objectId')) {
-            $query = 'ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`';
+            $query = 'ALTER TABLE `%s` CHANGE COLUMN `%s` `%s` int(11) NOT NULL';
             $this->addSql(sprintf($query, $table->getName(), 'objectId', 'o_id'));
         }
     }


### PR DESCRIPTION
Rename column is only introduced in MariaDB 10.5, minimum requirement of MariaDB is 10.3
See also https://github.com/pimcore/web2print-tools/issues/78#issuecomment-1596683953