### PR TITLE
Remove icon from field dialog

### DIFF
--- a/src/Resources/public/js/OutputDataConfigDialog.js
+++ b/src/Resources/public/js/OutputDataConfigDialog.js
@@ -46,7 +46,6 @@ pimcore.bundle.outputDataConfigToolkit.OutputDataConfigDialog = Class.create(pim
             width: 850,
             height: 650,
             modal: true,
-            iconCls: "bundle_outputdataconfig_icon",
             title: t('output_channel_definition_for') + " " + t(this.outputConfig.channel),
             layout: "fit",
             items: [this.configPanel]


### PR DESCRIPTION
Solved #93.

As suggestion, it's remove class from window. And 1 of reason it's consistency of dialogs - if check classic Admin UI - the mostly these dialog have no icons (ex.,Grid Config)