### PR TITLE
Fix null value Exception

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,10 @@
+name: Handle stale issues
+
+on:
+  workflow_dispatch:
+  schedule:
+      - cron: '37 7 * * *'
+
+jobs:
+  call-stale-workflow:
+    uses: pimcore/workflows-collection-public/.github/workflows/stale.yml@v1.1.0

--- a/src/ConfigElement/Value/Numeric.php
+++ b/src/ConfigElement/Value/Numeric.php
@@ -43,8 +43,10 @@ class Numeric extends DefaultValue
         if ($this->formatNumber) {
             $formatter = \Pimcore::getContainer()->get(\Pimcore\Localization\IntlFormatter::class);
 
-            //TODO consider precision
-            $labeledValue->value = $formatter->formatNumber($labeledValue->value);
+            if (!$labeledValue->empty) {
+                //TODO consider precision
+                $labeledValue->value = $formatter->formatNumber((float)$labeledValue->value);
+            }
         }
 
         return $labeledValue;


### PR DESCRIPTION
There is an Exception in the Pimcore Demo when rendering the products page

<img width="1483" alt="Screenshot 2024-03-02 at 18 10 21" src="https://github.com/pimcore/output-data-config-toolkit/assets/18331614/35d7c564-a1d9-4be8-a0d9-9b25937c3bdb">

`An exception has been thrown during the rendering of a template ("Pimcore\Localization\IntlFormatter::formatNumber(): Argument #1 ($value) must be of type int|float, null given, called in /var/www/html/vendor/pimcore/output-data-config-toolkit-bundle/src/ConfigElement/Value/Numeric.php on line 48"). File: /var/www/html/templates/areas/print-product-table/spec_attribute/column-attribute-table-header.html.twig Line: 13`

The problem is the header column "Price in EUR" does not have value and is marked as empty. 
<img width="478" alt="Screenshot 2024-03-02 at 18 13 17" src="https://github.com/pimcore/output-data-config-toolkit/assets/18331614/b6a122d0-67bd-4261-bb00-36714c46ef5d">