### PR TITLE
Allow customizations

### DIFF
--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -77,40 +77,7 @@ class DefaultValue extends AbstractConfigElement
                 $brickGetter = 'get' . ucfirst($brickKey);
             }
         } elseif (substr($this->attribute, 0, 4) == '#cs#') {
-            // checking classification store fieldname
-            if (!$this->classificationstore) {
-                return null;
-            }
-            $getter = 'get' . ucfirst($this->classificationstore);
-            // checking classification sote group
-            if (!$this->classificationstore_group) {
-                return null;
-            }
-            $groupDef = Classificationstore\GroupConfig::getByName($this->classificationstore_group);
-
-            // classification store
-            $attribute = str_replace('#cs#', '', $this->attribute);
-            list($keyId) = explode('#', $attribute);
-
-            $value = $object->$getter()->getLocalizedKeyValue($groupDef->getId(), $keyId);
-
-            $result = new \stdClass();
-            $result->value = $value;
-            $result->label = $this->label;
-            $result->attribute = $this->attribute;
-
-            $config = Classificationstore\KeyConfig::getById((int) $keyId);
-            if ($config) {
-                $result->def = Classificationstore\Service::getFieldDefinitionFromKeyConfig($config);
-            }
-
-            if (empty($value) || (is_object($value) && method_exists($value, 'isEmpty') && $value->isEmpty())) {
-                $result->empty = true;
-            } else {
-                $result->empty = false;
-            }
-
-            return $result;
+            return $this->getLabeledValueForClassificationStore($object);
         }
         if (method_exists($object, $getter)
             || (class_exists(DefaultMockup::class) && $object instanceof DefaultMockup)) {
@@ -185,5 +152,42 @@ class DefaultValue extends AbstractConfigElement
         }
 
         return null;
+    }
+
+    protected function getLabeledValueForClassificationStore($object): ?object {
+        // checking classification store fieldname
+        if (!$this->classificationstore) {
+            return null;
+        }
+        $getter = 'get' . ucfirst($this->classificationstore);
+        // checking classification sote group
+        if (!$this->classificationstore_group) {
+            return null;
+        }
+        $groupDef = Classificationstore\GroupConfig::getByName($this->classificationstore_group);
+
+        // classification store
+        $attribute = str_replace('#cs#', '', $this->attribute);
+        list($keyId) = explode('#', $attribute);
+
+        $value = $object->$getter()->getLocalizedKeyValue($groupDef->getId(), $keyId);
+
+        $result = new \stdClass();
+        $result->value = $value;
+        $result->label = $this->label;
+        $result->attribute = $this->attribute;
+
+        $config = Classificationstore\KeyConfig::getById((int) $keyId);
+        if ($config) {
+            $result->def = Classificationstore\Service::getFieldDefinitionFromKeyConfig($config);
+        }
+
+        if (empty($value) || (is_object($value) && method_exists($value, 'isEmpty') && $value->isEmpty())) {
+            $result->empty = true;
+        } else {
+            $result->empty = false;
+        }
+
+        return $result;
     }
 }

--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -154,7 +154,8 @@ class DefaultValue extends AbstractConfigElement
         return null;
     }
 
-    protected function getLabeledValueForClassificationStore($object): ?object {
+    protected function getLabeledValueForClassificationStore($object): ?object
+    {
         // checking classification store fieldname
         if (!$this->classificationstore) {
             return null;

--- a/src/Service.php
+++ b/src/Service.php
@@ -67,12 +67,12 @@ class Service
         return self::doBuildConfig($jsonConfig, $config, $context);
     }
 
-    private static function locateOperatorConfigClass($configElement): string
+    private static function locateConfigClass(string $type,$configElement): string
     {
         $namespaces = [
-            '\\OutputDataConfigToolkitBundle\\ConfigElement\\Operator\\',
-            '\\App\\OutputDataConfigToolkit\\ConfigElement\\Operator\\',
-            '\\AppBundle\\OutputDataConfigToolkit\\ConfigElement\\Operator\\'
+            '\\AppBundle\\OutputDataConfigToolkit\\ConfigElement\\' . $type . '\\',
+            '\\App\\OutputDataConfigToolkit\\ConfigElement\\' . $type . '\\',
+            '\\OutputDataConfigToolkitBundle\\ConfigElement\\' . $type . '\\',
         ];
 
         foreach ($namespaces as $namespace) {
@@ -90,13 +90,13 @@ class Service
         if (!empty($jsonConfig)) {
             foreach ($jsonConfig as $configElement) {
                 if ($configElement->type == 'value') {
-                    $name = '\\OutputDataConfigToolkitBundle\\ConfigElement\\Value\\' . ucfirst($configElement->class);
+                    $name = self::locateConfigClass('Value' , $configElement);
 
                     if (class_exists($name)) {
                         $config[] = new $name($configElement, $context);
                     }
                 } elseif ($configElement->type == 'operator') {
-                    $className = self::locateOperatorConfigClass($configElement);
+                    $className = self::locateConfigClass('Operator' , $configElement);
                     if (!empty($configElement->childs)) {
                         $configElement->childs = self::doBuildConfig($configElement->childs, [], $context);
                     }

--- a/src/Service.php
+++ b/src/Service.php
@@ -67,7 +67,7 @@ class Service
         return self::doBuildConfig($jsonConfig, $config, $context);
     }
 
-    private static function locateConfigClass(string $type,$configElement): string
+    private static function locateConfigClass(string $type, $configElement): string
     {
         $namespaces = [
             '\\AppBundle\\OutputDataConfigToolkit\\ConfigElement\\' . $type . '\\',
@@ -90,13 +90,13 @@ class Service
         if (!empty($jsonConfig)) {
             foreach ($jsonConfig as $configElement) {
                 if ($configElement->type == 'value') {
-                    $name = self::locateConfigClass('Value' , $configElement);
+                    $name = self::locateConfigClass('Value', $configElement);
 
                     if (class_exists($name)) {
                         $config[] = new $name($configElement, $context);
                     }
                 } elseif ($configElement->type == 'operator') {
-                    $className = self::locateConfigClass('Operator' , $configElement);
+                    $className = self::locateConfigClass('Operator', $configElement);
                     if (!empty($configElement->childs)) {
                         $configElement->childs = self::doBuildConfig($configElement->childs, [], $context);
                     }


### PR DESCRIPTION
This PR issues following features:

- Make also ConfigElement\Value classes extendable (same logic as it is for Config\Element\Operator)
- Fix the order of class names which are checked (first we need to check the App specific classes, and then the classes from the Bundles (otherwise we cannot get the extended version) )
- move the logic to get the values from the classification store to an own method (so it is easier to overwrite)

