### PR TITLE
fix output channels to work properly with classification stores

### DIFF
--- a/doc/classificationstore.md
+++ b/doc/classificationstore.md
@@ -16,7 +16,10 @@ different display modes for classification store keys in the output definition c
 for eq. 
 ```php
     $outputDataConfig = OutputDataConfigToolkitBundle\Service::getOutputDataConfig($object, 'Output config channel');
-    $outputDataConfig[0]->classificationstore = 'Attributes';     ### classificationstore field name in object 
-    $outputDataConfig[0]->classificationstore_group = 'Product';  ### Classificationstore group name
+    $outputDataConfig[0]->setClassificationstore('Attributes');     ### classificationstore field name in object 
+    $outputDataConfig[0]->setClassificationstoreGroup('Product');  ### Classificationstore group name
+    # the old way was access the values directly
+    // $outputDataConfig[0]->classificationstore = 'Attributes';     ### classificationstore field name in object 
+    // $outputDataConfig[0]->classificationstore_group = 'Product';  ### Classificationstore group name
     $outputDataConfig[0]->getLabeledValue($object);
 ```

--- a/src/ConfigElement/AbstractConfigElement.php
+++ b/src/ConfigElement/AbstractConfigElement.php
@@ -22,6 +22,12 @@ abstract class AbstractConfigElement implements IConfigElement
 
     protected $context;
 
+    /** @var string|null */
+    public ?string $classificationstore = null;
+
+    /** @var string|null */
+    public ?string $classificationstore_group = null;
+
     public function __construct($config, $context = null)
     {
         $this->attribute = $config->attribute ?? null;
@@ -33,5 +39,25 @@ abstract class AbstractConfigElement implements IConfigElement
     public function getLabel()
     {
         return $this->label;
+    }
+
+    public function getClassificationstore(): ?string
+    {
+        return $this->classificationstore;
+    }
+
+    public function getClassificationstoreGroup(): ?string
+    {
+        return $this->classificationstore_group;
+    }
+
+    public function setClassificationstore(?string $classificationstore): void
+    {
+        $this->classificationstore = $classificationstore;
+    }
+
+    public function setClassificationstoreGroup(?string $classificationstore_group): void
+    {
+        $this->classificationstore_group = $classificationstore_group;
     }
 }

--- a/src/ConfigElement/AbstractConfigElement.php
+++ b/src/ConfigElement/AbstractConfigElement.php
@@ -60,7 +60,7 @@ abstract class AbstractConfigElement implements IConfigElement
     {
         $this->classificationstore_group = $classificationstore_group;
     }
-    
+
     public function getAttribute()
     {
         return $this->attribute;

--- a/src/ConfigElement/Operator/Concatenator.php
+++ b/src/ConfigElement/Operator/Concatenator.php
@@ -15,6 +15,9 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
+use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
+use OutputDataConfigToolkitBundle\ConfigElement\Value\DefaultValue;
+
 class Concatenator extends AbstractOperator
 {
     protected $glue;
@@ -44,6 +47,11 @@ class Concatenator extends AbstractOperator
         $valueArray = [];
 
         foreach ($childs as $c) {
+            if ($c instanceof AbstractConfigElement) {
+                $c->setClassificationstore($this->getClassificationstore());
+                $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
+            }
+                
             $value = $c->getLabeledValue($object) ? $c->getLabeledValue($object)->value : null;
 
             if (!$hasValue) {

--- a/src/ConfigElement/Operator/Concatenator.php
+++ b/src/ConfigElement/Operator/Concatenator.php
@@ -16,7 +16,6 @@
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
 use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
-use OutputDataConfigToolkitBundle\ConfigElement\Value\DefaultValue;
 
 class Concatenator extends AbstractOperator
 {
@@ -51,7 +50,7 @@ class Concatenator extends AbstractOperator
                 $c->setClassificationstore($this->getClassificationstore());
                 $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
             }
-                
+
             $value = $c->getLabeledValue($object) ? $c->getLabeledValue($object)->value : null;
 
             if (!$hasValue) {

--- a/src/ConfigElement/Operator/Group.php
+++ b/src/ConfigElement/Operator/Group.php
@@ -15,6 +15,8 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
+use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
+
 class Group extends AbstractOperator
 {
     public function getLabeledValue($object)
@@ -23,6 +25,10 @@ class Group extends AbstractOperator
 
         $childs = $this->getChilds();
         foreach ($childs as $c) {
+            if ($c instanceof AbstractConfigElement) {
+                $c->setClassificationstore($this->getClassificationstore());
+                $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
+            }
             $value = $c->getLabeledValue($object);
             if (!empty($value) && !$value->empty && (!method_exists($value, 'isEmpty') || !$value->isEmpty())) {
                 $valueArray[] = $value;

--- a/src/ConfigElement/Operator/Table.php
+++ b/src/ConfigElement/Operator/Table.php
@@ -15,6 +15,8 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
+use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
+
 class Table extends AbstractOperator
 {
     protected $tooltip;
@@ -37,6 +39,10 @@ class Table extends AbstractOperator
         $isEmpty = false;
         $valueArray = [];
         foreach ($childs as $c) {
+            if ($c instanceof AbstractConfigElement) {
+                $c->setClassificationstore($this->getClassificationstore());
+                $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
+            }
             $row = $c->getLabeledValue($object);
             $valueArray[] = $row;
             $isEmpty = $row->empty;

--- a/src/ConfigElement/Operator/TableCol.php
+++ b/src/ConfigElement/Operator/TableCol.php
@@ -15,6 +15,8 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
+use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
+
 class TableCol extends AbstractOperator
 {
     protected $colspan;
@@ -34,7 +36,12 @@ class TableCol extends AbstractOperator
 
         $childs = $this->getChilds();
         if ($childs) {
-            $value = $childs[0]->getLabeledValue($object);
+            $c = $childs[0];
+            if ($c instanceof AbstractConfigElement) {
+                $c->setClassificationstore($this->getClassificationstore());
+                $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
+            }
+            $value = $c->getLabeledValue($object);
             $value->colSpan = $this->colspan;
             $value->headline = $this->headline;
 

--- a/src/ConfigElement/Operator/TableRow.php
+++ b/src/ConfigElement/Operator/TableRow.php
@@ -15,6 +15,8 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
+use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
+
 class TableRow extends AbstractOperator
 {
     protected $headline;
@@ -35,6 +37,10 @@ class TableRow extends AbstractOperator
         $valueArray = [];
 
         foreach ($childs as $c) {
+            if ($c instanceof AbstractConfigElement) {
+                $c->setClassificationstore($this->getClassificationstore());
+                $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
+            }
             $col = $c->getLabeledValue($object);
             if (!empty($col) && (!$col->empty && !($c instanceof \OutputDataConfigToolkitBundle\ConfigElement\Operator\Text))) {
                 $isEmpty = false;

--- a/src/ConfigElement/Operator/TextAddon.php
+++ b/src/ConfigElement/Operator/TextAddon.php
@@ -15,6 +15,8 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
+use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
+
 class TextAddon extends AbstractOperator
 {
     private $addon;
@@ -30,7 +32,12 @@ class TextAddon extends AbstractOperator
     {
         $childs = $this->getChilds();
         if (!empty($childs)) {
-            $value = $childs[0]->getLabeledValue($object);
+            $c = $childs[0];
+            if ($c instanceof AbstractConfigElement) {
+                $c->setClassificationstore($this->getClassificationstore());
+                $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
+            }
+            $value = $c->getLabeledValue($object);
 
             if (!is_null($value->value)) {
                 $value->value = $value->value.$this->getAddon();

--- a/src/ConfigElement/Operator/TranslateValue.php
+++ b/src/ConfigElement/Operator/TranslateValue.php
@@ -15,6 +15,8 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Operator;
 
+use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
+
 class TranslateValue extends AbstractOperator
 {
     private $prefix;
@@ -31,8 +33,12 @@ class TranslateValue extends AbstractOperator
         $childs = $this->getChilds();
         if ($childs) {
             $translator = \Pimcore::getContainer()->get('translator');
-
-            $value = $childs[0]->getLabeledValue($object);
+            $c = $childs[0];
+            if ($c instanceof AbstractConfigElement) {
+                $c->setClassificationstore($this->getClassificationstore());
+                $c->setClassificationstoreGroup($this->getClassificationstoreGroup());
+            }
+            $value = $c->getLabeledValue($object);
             if ($value->value) {
                 $value->value = $translator->trans($this->prefix . $value->value);
             }

--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -29,11 +29,11 @@ class DefaultValue extends AbstractConfigElement
     /** @var string|null */
     protected $icon;
 
-    /** @var string|null */
-    public $classificationstore;
+    // /** @var string|null */
+    // public $classificationstore;
 
-    /** @var string|null */
-    public $classificationstore_group;
+    // /** @var string|null */
+    // public $classificationstore_group;
 
     public function __construct($config, $context = null)
     {
@@ -78,15 +78,15 @@ class DefaultValue extends AbstractConfigElement
             }
         } elseif (substr($this->attribute, 0, 4) == '#cs#') {
             // checking classification store fieldname
-            if (!$this->classificationstore) {
+            if (!$this->getClassificationstore()) {
                 return null;
             }
-            $getter = 'get' . ucfirst($this->classificationstore);
+            $getter = 'get' . ucfirst($this->getClassificationstore());
             // checking classification sote group
-            if (!$this->classificationstore_group) {
+            if (!$this->getClassificationstoreGroup()) {
                 return null;
             }
-            $groupDef = Classificationstore\GroupConfig::getByName($this->classificationstore_group);
+            $groupDef = Classificationstore\GroupConfig::getByName($this->getClassificationstoreGroup());
 
             // classification store
             $attribute = str_replace('#cs#', '', $this->attribute);

--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -29,12 +29,6 @@ class DefaultValue extends AbstractConfigElement
     /** @var string|null */
     protected $icon;
 
-    // /** @var string|null */
-    // public $classificationstore;
-
-    // /** @var string|null */
-    // public $classificationstore_group;
-
     public function __construct($config, $context = null)
     {
         parent::__construct($config, $context);


### PR DESCRIPTION
When using output channels with more configuration than DefaultValue, the classification store values are passed through to child elements. So for example the concatenator operator works correctly.