### PR TITLE
property empty might not always exist

### DIFF
--- a/src/ConfigElement/Operator/Group.php
+++ b/src/ConfigElement/Operator/Group.php
@@ -24,7 +24,7 @@ class Group extends AbstractOperator
         $childs = $this->getChilds();
         foreach ($childs as $c) {
             $value = $c->getLabeledValue($object);
-            if (!empty($value) && !$value->empty && (!method_exists($value, 'isEmpty') || !$value->isEmpty())) {
+            if (!empty($value) && (!property_exists($value, 'empty') || !$value->empty) && (!method_exists($value, 'isEmpty') || !$value->isEmpty())) {
                 $valueArray[] = $value;
             }
         }


### PR DESCRIPTION
In Case of the child being a Concatenator there might be no empty property