### PR TITLE
Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "~8.3.0 || ~8.4.0",
-    "pimcore/pimcore": "^12.0",
+    "pimcore/pimcore": "^12.3",
     "symfony/event-dispatcher-contracts": "^3.0"
   },
   "require-dev": {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -12,6 +12,7 @@
 
 namespace OutputDataConfigToolkitBundle\Controller;
 
+use Pimcore\Helper\ParameterBagHelper;
 use OutputDataConfigToolkitBundle\Event\InitializeEvent;
 use OutputDataConfigToolkitBundle\Event\OutputDataConfigToolkitEvents;
 use OutputDataConfigToolkitBundle\Event\SaveConfigEvent;
@@ -67,7 +68,7 @@ class AdminController extends UserAwareController
     #[Route('/initialize')]
     public function initializeAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
-        $objectId = $request->query->getInt('id');
+        $objectId = ParameterBagHelper::getInt($request->query, 'id');
         $object = AbstractObject::getById($objectId);
 
         if (!$object) {
@@ -98,7 +99,7 @@ class AdminController extends UserAwareController
         Service::initChannelsForRootobject();
         $channels = Service::getChannels();
 
-        $objectId = $request->request->getInt('object_id');
+        $objectId = ParameterBagHelper::getInt($request->request, 'object_id');
         $object = AbstractObject::getById($objectId);
 
         $classList = $this->getFilteredClassDefinitionList($request);
@@ -159,7 +160,7 @@ class AdminController extends UserAwareController
     public function resetOutputConfigAction(Request $request)
     {
         try {
-            $config = OutputDefinition::getById($request->query->getInt('config_id'));
+            $config = OutputDefinition::getById(ParameterBagHelper::getInt($request->query, 'config_id'));
             $config->delete();
 
             return $this->jsonResponse(['success' => true]);
@@ -179,7 +180,7 @@ class AdminController extends UserAwareController
     public function getOutputConfigAction(Request $request)
     {
         try {
-            $config = OutputDefinition::getById($request->query->getInt('config_id'));
+            $config = OutputDefinition::getById(ParameterBagHelper::getInt($request->query, 'config_id'));
 
             $objectClass = ClassDefinition::getById($config->getClassId());
             $configuration = json_decode($config->getConfiguration());
@@ -204,7 +205,7 @@ class AdminController extends UserAwareController
     public function getOrCreateOutputConfigAction(Request $request)
     {
         try {
-            $config = OutputDefinition::getById($request->query->getInt('config_id'));
+            $config = OutputDefinition::getById(ParameterBagHelper::getInt($request->query, 'config_id'));
             $class = null;
             if (!$config) {
                 if ($request->query->has('class_id')) {
@@ -214,7 +215,7 @@ class AdminController extends UserAwareController
                     throw new \Exception('Class ' . $request->query->getString('class_id') . ' not found.');
                 }
 
-                $config = OutputDefinition::getByObjectIdClassIdChannel($request->query->getInt('objectId'), $class->getId(), $request->query->getString('channel'));
+                $config = OutputDefinition::getByObjectIdClassIdChannel(ParameterBagHelper::getInt($request->query, 'objectId'), $class->getId(), $request->query->getString('channel'));
             }
 
             if ($config) {
@@ -228,7 +229,7 @@ class AdminController extends UserAwareController
                 $config = new OutputDefinition();
                 $config->setChannel($request->query->getString('channel'));
                 $config->setClassId($class->getId());
-                $config->setObjectId($request->query->getInt('objectId'));
+                $config->setObjectId(ParameterBagHelper::getInt($request->query, 'objectId'));
                 $config->save();
 
                 return $this->jsonResponse(['success' => true, 'outputConfig' => $config]);
@@ -412,13 +413,13 @@ class AdminController extends UserAwareController
     public function saveOutputConfigAction(Request $request, EventDispatcherInterface $eventDispatcher)
     {
         try {
-            $config = OutputDefinition::getById($request->request->getInt('config_id'));
+            $config = OutputDefinition::getById(ParameterBagHelper::getInt($request->request, 'config_id'));
 
-            $object = AbstractObject::getById($request->request->getInt('object_id'));
+            $object = AbstractObject::getById(ParameterBagHelper::getInt($request->request, 'object_id'));
             if (empty($object)) {
-                throw new \Exception('Data Object with ID' . $request->request->getInt('object_id') . ' not found.');
+                throw new \Exception('Data Object with ID' . ParameterBagHelper::getInt($request->request, 'object_id') . ' not found.');
             }
-            if ($config->getObjectId() != $request->request->getInt('object_id')) {
+            if ($config->getObjectId() != ParameterBagHelper::getInt($request->request, 'object_id')) {
                 $newConfig = new OutputDefinition();
                 $newConfig->setChannel($config->getChannel());
                 $newConfig->setClassId($config->getClassId());

--- a/src/Controller/ClassController.php
+++ b/src/Controller/ClassController.php
@@ -12,6 +12,7 @@
 
 namespace OutputDataConfigToolkitBundle\Controller;
 
+use Pimcore\Helper\ParameterBagHelper;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use OutputDataConfigToolkitBundle\Constant\ColumnConfigDisplayMode;
 use OutputDataConfigToolkitBundle\Event;
@@ -54,7 +55,7 @@ class ClassController extends UserAwareController
     {
         $classId = $request->query->getString('id');
         $class = DataObject\ClassDefinition::getById($classId);
-        $objectId = $request->query->getInt('oid');
+        $objectId = ParameterBagHelper::getInt($request->query, 'oid');
 
         $filteredDefinitions = DataObject\Service::getCustomLayoutDefinitionForGridColumnConfig($class, $objectId);
 
@@ -128,7 +129,7 @@ class ClassController extends UserAwareController
         $enrichment = false;
         $grouped = $this->getClassificationGroupedDisplay();
         if ($displayMode == ColumnConfigDisplayMode::DATA_OBJECT || $displayMode == ColumnConfigDisplayMode::RELEVANT) {
-            $targetObjectId = $request->query->getInt('target_oid');
+            $targetObjectId = ParameterBagHelper::getInt($request->query, 'target_oid');
 
             if ($targetObject = DataObject\Concrete::getById($targetObjectId)) {
                 $class->setFieldDefinitions($fieldDefinitions);


### PR DESCRIPTION
This pull request refactors how integer parameters are retrieved from HTTP requests in both `AdminController.php` and `ClassController.php`. Instead of using the native Symfony `getInt` method, the code now consistently uses `ParameterBagHelper::getInt`. This change improves robustness and consistency in parameter handling across the controllers.

**Parameter retrieval improvements:**

* All integer parameters from request objects in `AdminController.php` are now retrieved using `ParameterBagHelper::getInt` instead of `$request->query->getInt` or `$request->request->getInt`. This affects object and config IDs in methods such as `initializeAction`, `getOutputConfigsAction`, `resetOutputConfigAction`, `getOutputConfigAction`, `getOrCreateOutputConfigAction`, and `saveOutputConfigAction`. [[1]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L70-R71) [[2]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L101-R102) [[3]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L162-R163) [[4]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L182-R183) [[5]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L207-R208) [[6]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L217-R218) [[7]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L231-R232) [[8]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L415-R422)

**Consistency applied to `ClassController.php`:**

* Integer parameters in `ClassController.php` are now also retrieved using `ParameterBagHelper::getInt`, specifically for `oid` and `target_oid` in relevant methods. [[1]](diffhunk://#diff-75de0ec7d4a3efd3a5ee4281771eb484910ee1ca5c95fadcc6e182e0575a2c4bL57-R58) [[2]](diffhunk://#diff-75de0ec7d4a3efd3a5ee4281771eb484910ee1ca5c95fadcc6e182e0575a2c4bL131-R132)

**General codebase consistency:**

* The `ParameterBagHelper` import was added to both controllers to support the new retrieval method. [[1]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7R15) [[2]](diffhunk://#diff-75de0ec7d4a3efd3a5ee4281771eb484910ee1ca5c95fadcc6e182e0575a2c4bR15)