### PR TITLE
Use reusable POEditor export workflow

### DIFF
--- a/.github/workflows/new-poeditor-export.yml
+++ b/.github/workflows/new-poeditor-export.yml
@@ -1,0 +1,21 @@
+name: "Trigger POEditor Translations Export"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "[0-9]+.x"
+      - "docs_actions"
+      - "main"
+    paths:
+      - "src/Resources/translations/admin.en.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  poeditor:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-poeditor.yaml@main
+    secrets:
+      POEDITOR_ACTION_TRIGGER_TOKEN: ${{ secrets.POEDITOR_ACTION_TRIGGER_TOKEN }}
+

--- a/.github/workflows/poeditor-export.yml.bak
+++ b/.github/workflows/poeditor-export.yml.bak
@@ -1,0 +1,22 @@
+name: "Trigger POEditor Translations Export"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "[0-9]+.x"
+    paths:
+      - 'src/Resources/translations/admin.en.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  poeditor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger workflow in pimcore/poeditor-export-action
+        env:
+          GH_TOKEN: ${{ secrets.POEDITOR_ACTION_TRIGGER_TOKEN }}
+        run: |
+          gh workflow run -R pimcore/poeditor-export-action poeditor-export.yaml


### PR DESCRIPTION
This PR migrates POEditor workflow to the reusable Pimcore POEditor workflow.