### PR TITLE
Sync non-matrix workflows with 6.2 (#1305)

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cla-workflow:
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-cla-check.yaml@v1.3.0
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-cla-check.yaml@main
     if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
     secrets:
       CLA_ACTION_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}

--- a/.github/workflows/php-style.yml
+++ b/.github/workflows/php-style.yml
@@ -1,20 +1,21 @@
-name: PHP Style
+name: "PHP-CS-Fixer"
 
-on: [push]
+on:
+    push:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+
+permissions:
+    contents: write
 
 jobs:
-    php-cs-fixer:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  ref: ${{ github.head_ref }}
-
-            - name: PHP-CS-Fixer
-              uses: docker://oskarstark/php-cs-fixer-ga:2.19.0
-              with:
-                args: --config=.php_cs.dist --allow-risky yes
-
-            - uses: stefanzweifel/git-auto-commit-action@v4
-              with:
-                  commit_message: Apply php-cs-fixer changes
+    php-style:
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+        if: github.repository_owner == 'pimcore'
+        secrets:
+            PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}
+        with:
+            head_ref: ${{ github.head_ref || github.ref_name }}
+            repository: ${{ github.repository }}
+            config_file: .php-cs-fixer.dist.php

--- a/.github/workflows/poeditor-export.yml
+++ b/.github/workflows/poeditor-export.yml
@@ -5,18 +5,17 @@ on:
   push:
     branches:
       - "[0-9]+.x"
+      - "docs_actions"
+      - "main"
     paths:
-      - 'src/Resources/translations/admin.en.yml'
+      - "src/Resources/translations/admin.en.yml"
 
 permissions:
   contents: read
 
 jobs:
   poeditor:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger workflow in pimcore/poeditor-export-action
-        env:
-          GH_TOKEN: ${{ secrets.POEDITOR_ACTION_TRIGGER_TOKEN }}
-        run: |
-          gh workflow run -R pimcore/poeditor-export-action poeditor-export.yaml
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-poeditor.yaml@main
+    secrets:
+      POEDITOR_ACTION_TRIGGER_TOKEN: ${{ secrets.POEDITOR_ACTION_TRIGGER_TOKEN }}
+


### PR DESCRIPTION
Part of product-management#1305, Wave 3 (2024.4 / LTS branches). Same recipe as the previous waves. Reference branch: `6.2`. Every adopted file is byte-identical to it. Codeception / static-analysis workflows untouched (matrix class).

Changes:` adopt:cla-check.yaml adopt:php-style.yml adopt:poeditor-export.yml`

**PCL line — no forward-merge will follow** (cross-license boundary: changes travel by cherry-pick only, and PCL lines are separate release tracks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)